### PR TITLE
Fix Flang stdlib linking for LLVM toolchain versions >= 19

### DIFF
--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -643,7 +643,11 @@ class LlvmFlangFortranCompiler(ClangCompiler, FortranCompiler):
         # https://github.com/llvm/llvm-project/commit/8d5386669ed63548daf1bee415596582d6d78d7d;
         # it seems flang 18 doesn't work if something accidentally includes a program unit, see
         # https://github.com/llvm/llvm-project/issues/92496
-        return search_dirs + ['-lFortranRuntime', '-lFortranDecimal']
+        # Only link FortranRuntime and FortranDecimal for flang < 19, see
+        # https://github.com/scipy/scipy/issues/21562#issuecomment-2942938509
+        if version_compare(self.version, '<19'):
+            search_dirs += ['-lFortranRuntime', '-lFortranDecimal']
+        return search_dirs
 
 
 class Open64FortranCompiler(FortranCompiler):


### PR DESCRIPTION
- Currently, I am trying to build SciPy for Windows ARM64 using LLVM toolchain v19.1.5(flang-new+clang-cl). SciPy uses meson build setup for building from source.
- Upon building SciPy with LLVM toolchain v19.1.15 using meson, the build fails due to missing static library  "FortranRuntime.lib" [see[ here](https://github.com/scipy/scipy/issues/21562#issuecomment-2942938509)].
- Flang 19 and newer no longer require these libraries to be explicitly linked, and their presence causes build failures on Windows ARM64 with missing .lib files.
- This patch updates [language_stdlib_only_link_flags()](https://github.com/mesonbuild/meson/blob/4779abbf3eaf41c2893ef74c4d79f5e894af64d7/mesonbuild/compilers/fortran.py#L635) to conditionally add -lFortranRuntime and -lFortranDecimal only for Flang versions < 19.  This change enables successful builds of SciPy for win_arm64 using Flang 19+.

CC: @rgommers